### PR TITLE
WIP: [ldap backend] add ldaps:// support

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,17 +110,18 @@ Parameters for this backend are JSON-encoded!
 | ------------------|------------------------------------------------------------------------------------------|
 | host              | host, required - i.e. ldap.example.com |
 | port              | port, optional (default 389)           |
+| simpleTls         | ldap over SSL (``ldaps://``) (default false), if ``true`` ``tls`` option is ignored |
 | tls               | should StartTLS be used? (default false) |
 | bindUsername      | (read-only) bind username - i.e. ldap-auth |
 | bindPassword      | the password for the bind username         |
-| skipverify        | true to ignore TLS errors (optional, false by default)                                   |
+| insecure          | true to ignore TLS errors (optional, false by default), used with ``simpleTls`` or ``tls``|
 | timeout           | request timeout (optional 1m by default, go duration syntax is supported)                |
 | base              | Search base, for example "OU=Users,OU=Company,DC=example,DC=com"                         |
 | filter            | Filter the users, for example "(&(memberOf=CN=group,OU=Users,OU=Company,DC=example,DC=com)(objectClass=user)(sAMAccountName=%s))"                                                   |
 
 Example
 ```
-	ldap {"url":"ldap://ldap-auth:passw@ldap.example.com:389","timeout":"5s","skipverify":true,"base":"OU=Users,OU=Company,DC=example,DC=com","filter":"(&(memberOf=CN=group,OU=Users,OU=Company,DC=example,DC=com)(objectClass=user)(sAMAccountName=%s))"}
+	ldap {"host":"ldap.example.com","port":389,"timeout":"5s","insecure":true,"base":"OU=Users,OU=Company,DC=example,DC=com","filter":"(&(memberOf=CN=group,OU=Users,OU=Company,DC=example,DC=com)(objectClass=user)(sAMAccountName=%s))"}
 ```
 
 ## Failure handlers

--- a/backends/backends.go
+++ b/backends/backends.go
@@ -25,10 +25,10 @@
 package backends
 
 import (
-	_ "github.com/freman/caddy-reauth/backends/gitlabci"
-	_ "github.com/freman/caddy-reauth/backends/ldap"
-	_ "github.com/freman/caddy-reauth/backends/simple"
-	_ "github.com/freman/caddy-reauth/backends/upstream"
+	_ "github.com/petrus-v/caddy-reauth/backends/gitlabci"
+	_ "github.com/petrus-v/caddy-reauth/backends/ldap"
+	_ "github.com/petrus-v/caddy-reauth/backends/simple"
+	_ "github.com/petrus-v/caddy-reauth/backends/upstream"
 )
 
 // This page intentionally left blank ;)

--- a/backends/gitlabci/auth.go
+++ b/backends/gitlabci/auth.go
@@ -34,7 +34,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/freman/caddy-reauth/backend"
+	"github.com/petrus-v/caddy-reauth/backend"
 )
 
 // Backend name

--- a/backends/ldap/auth.go
+++ b/backends/ldap/auth.go
@@ -34,7 +34,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/freman/caddy-reauth/backend"
+	"github.com/petrus-v/caddy-reauth/backend"
 
 	ldp "gopkg.in/ldap.v2"
 )

--- a/backends/ldap/auth.go
+++ b/backends/ldap/auth.go
@@ -56,6 +56,7 @@ const DefaultFilter = "(&(objectClass=user)(sAMAccountName=%s))"
 type LDAP struct {
 	Host               string        `json:"host"`
 	Port               int           `json:"port"`
+	SimpleTLS          bool          `json:"simpleTls"`
 	TLS                bool          `json:"tls"`
 	Timeout            time.Duration `json:"timeout"`
 	InsecureSkipVerify bool          `json:"insecure"`
@@ -194,18 +195,27 @@ func (h *LDAP) Close() error {
 
 func (h *LDAP) connect() error {
 	hostport := fmt.Sprintf("%s:%d", h.Host, h.Port)
-	l, err := ldp.Dial("tcp", hostport)
-	if err != nil {
-		return fmt.Errorf("connect to %q: %v", hostport, err)
-	}
-	if h.TLS {
-		if err = l.StartTLS(&tls.Config{InsecureSkipVerify: h.InsecureSkipVerify}); err != nil {
-			l.Close()
-			return fmt.Errorf("StartTLS: %v", err)
+	var l *ldp.Conn
+	var err error
+	if h.SimpleTLS {
+		l, err = ldp.DialTLS("tcp", hostport, &tls.Config{InsecureSkipVerify: h.InsecureSkipVerify})
+		if err != nil {
+			return fmt.Errorf("connect to %q: %v", hostport, err)
+		}
+	} else {
+		l, err = ldp.Dial("tcp", hostport)
+		if err != nil {
+			return fmt.Errorf("connect to %q: %v", hostport, err)
+		}
+		if h.TLS {
+			if err = l.StartTLS(&tls.Config{InsecureSkipVerify: h.InsecureSkipVerify}); err != nil {
+				l.Close()
+				return fmt.Errorf("StartTLS: %v", err)
+			}
 		}
 	}
 	// First bind with a read only user
-	if err = l.Bind(h.BindUsername, h.BindPassword); err != nil {
+	if err := l.Bind(h.BindUsername, h.BindPassword); err != nil {
 		l.Close()
 		return fmt.Errorf("bind with %q: %v", h.BindUsername, err)
 	}

--- a/backends/simple/auth.go
+++ b/backends/simple/auth.go
@@ -27,7 +27,7 @@ package simple
 import (
 	"net/http"
 
-	"github.com/freman/caddy-reauth/backend"
+	"github.com/petrus-v/caddy-reauth/backend"
 )
 
 // Backend name

--- a/backends/upstream/auth.go
+++ b/backends/upstream/auth.go
@@ -33,7 +33,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/freman/caddy-reauth/backend"
+	"github.com/petrus-v/caddy-reauth/backend"
 )
 
 // Backend name

--- a/config.go
+++ b/config.go
@@ -27,8 +27,8 @@ package reauth
 import (
 	"fmt"
 
-	"github.com/freman/caddy-reauth/backend"
-	_ "github.com/freman/caddy-reauth/backends"
+	"github.com/petrus-v/caddy-reauth/backend"
+	_ "github.com/petrus-v/caddy-reauth/backends"
 
 	"github.com/mholt/caddy"
 )

--- a/config_test.go
+++ b/config_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/freman/caddy-reauth/backend"
+	"github.com/petrus-v/caddy-reauth/backend"
 	"github.com/mholt/caddy"
 )
 

--- a/failure.go
+++ b/failure.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/freman/caddy-reauth/backend"
+	"github.com/petrus-v/caddy-reauth/backend"
 )
 
 type failure interface {


### PR DESCRIPTION
I know ldap over ssl is deprecated but still quite used, add some support for it

I expect to add some unit-test that why I have prefixed with WIP.

Probably in an other PR I would support an other syntax style I don't feel online json format pretty readable, I mean support both syntax likes:

``json`` format for compatibilty:
```Caddyfile
reauth {
    path /
    ldap {"host":"ldap.example.com","port":389....}
}
```
for convenience, homogeneity and readability:
```Caddyfile
reauth {
    path /
    ldap {
        host ldap.example.com
        port 389
        ...
    }
}
```
what do you think about ? 

Finally, does it will be welcome if I create a third PR to launch unit test by travis ci ?

