### PR TITLE
Removed unused import

### DIFF
--- a/backends/gitlabci/auth.go
+++ b/backends/gitlabci/auth.go
@@ -31,7 +31,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/freman/caddy-reauth/backend"


### PR DESCRIPTION
The need for `strings` was removed in 3a1c2d335c93ecc5d48c0e7336473ad2abf4810b... which results in the package not building anymore.