### PR TITLE
Fix LDAP auth documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,19 +194,19 @@ Parameters for this backend are JSON-encoded!
 
 | Parameter-Name    | Description                                                                              |
 | ------------------|------------------------------------------------------------------------------------------|
-| host              | host, required - i.e. ldap.example.com |
+| host              | host, required - i.e. `ldap.example.com` |
 | port              | port, optional (default 389)           |
 | tls               | should StartTLS be used? (default false) |
-| bindUsername      | (read-only) bind username - i.e. ldap-auth |
+| bindUsername      | (read-only) bind DN - i.e. `ldap-auth` or `uid=ldap-auth,OU=Users,OU=Company,DC=example,DC=com if server requires fully qualified DN` |
 | bindPassword      | the password for the bind username         |
-| skipverify        | true to ignore TLS errors (optional, false by default)                                   |
+| insecure          | true to ignore TLS errors (optional, false by default)                                   |
 | timeout           | request timeout (optional 1m by default, go duration syntax is supported)                |
-| base              | Search base, for example "OU=Users,OU=Company,DC=example,DC=com"                         |
-| filter            | Filter the users, for example "(&(memberOf=CN=group,OU=Users,OU=Company,DC=example,DC=com)(objectClass=user)(sAMAccountName=%s))"                                                   |
+| base              | Search base, for example `OU=Users,OU=Company,DC=example,DC=com`                         |
+| filter            | Filter the users, for example `(&(memberOf=CN=group,OU=Users,OU=Company,DC=example,DC=com)(objectClass=user)(sAMAccountName=%s))`                                                   |
 
 Example
 ```
-	ldap {"url":"ldap://ldap-auth:passw@ldap.example.com:389","timeout":"5s","skipverify":true,"base":"OU=Users,OU=Company,DC=example,DC=com","filter":"(&(memberOf=CN=group,OU=Users,OU=Company,DC=example,DC=com)(objectClass=user)(sAMAccountName=%s))"}
+	ldap {"host":"ldap.example.com","port":389,"bindUsername":"ldap-auth","bindPassword":"passw","timeout":"5s","insecure":true,"base":"OU=Users,OU=Company,DC=example,DC=com","filter":"(&(memberOf=CN=group,OU=Users,OU=Company,DC=example,DC=com)(objectClass=user)(sAMAccountName=%s))"}
 ```
 
 ## Failure handlers


### PR DESCRIPTION
- LDAP backend documentation in README references invalid `url` and                                                                                                          
  `skipverify` parameters                                                                                                          
- The `bindUsername` is actually a bind DN.                                                                                                          
