### PR TITLE
add authenticated flag to ldap configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Parameters for this backend:
 | filter           | Filter the users, eg "(&(memberOf=CN=group,OU=Users,OU=Company,DC=example,DC=com)(objectClass=user)(sAMAccountName=%s))" |
 | principal_suffix | suffix to append to usernames (eg: @example.com)                                                                         |
 | pool_size        | size of the connection pool, default is 10                                                                               |
+| authenticated    | true to force password be filled even server allow UNAUTHENTICATED login                                                 |
 
 Example
 ```

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Parameters for this backend:
 | filter           | Filter the users, eg "(&(memberOf=CN=group,OU=Users,OU=Company,DC=example,DC=com)(objectClass=user)(sAMAccountName=%s))" |
 | principal_suffix | suffix to append to usernames (eg: @example.com)                                                                         |
 | pool_size        | size of the connection pool, default is 10                                                                               |
-| authenticated    | true to force password be filled even server allow UNAUTHENTICATED login                                                 |
+| authenticated    | true don't allow login with empty passwords (optional, false by default)                                                 |
 
 Example
 ```

--- a/backends/ldap/auth.go
+++ b/backends/ldap/auth.go
@@ -147,12 +147,9 @@ func constructor(config string) (backend.Backend, error) {
 	}
 
 	if s, found := options["authenticated"]; found {
-		if s == "true" {
-			us.authenticated = true
-		} else if s == "false" {
-			us.authenticated = false
-		} else {
-			return nil, fmt.Errorf("unable to parse authenticated %s: authenticated must be true or false", s)
+		us.authenticated, err = strconv.ParseBool(s)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse authenticated %q: %v", s, err)
 		}
 	}
 


### PR DESCRIPTION
When server is using LDAP authentication and you type a valid user and keep password empty access is granted. It is because LDAP simple authentication allow one method called UNAUTHENTICATED described here https://tools.ietf.org/html/rfc4513#section-5.1.2 .

Normally login interfaces require non empty password but HTTP basic auth does not. The PR add a flag to force non empty password even if LDAP server allow unauthenticated login.

If it is false or not informed authentication behavior does not change.